### PR TITLE
Fix ceph-admin dependency

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,6 +1,6 @@
 includes:
   - layer:basic
   - layer:apt
-  - interface:/home/chris/repos/juju-interface-ceph-admin
+  - interface:ceph-admin
 
 repo: git@github.com:cholcombe973/openattic-charm.git


### PR DESCRIPTION
ceph admin was used with local path. Use layer index instead.